### PR TITLE
Postal code optional

### DIFF
--- a/examples/getMoreCIFs.php
+++ b/examples/getMoreCIFs.php
@@ -16,6 +16,7 @@ foreach ($companies as $company) {
     echo $company->getAddress()->getCounty();
     echo $company->getAddress()->getStreet();
     echo $company->getAddress()->getStreetNumber();
+    echo $company->getAddress()->getPostalCode();
 
     // ... etc
 }

--- a/examples/getOneCIF.php
+++ b/examples/getOneCIF.php
@@ -14,5 +14,6 @@ echo $company->getAddress()->getCounty();
 echo $company->getAddress()->getCounty();
 echo $company->getAddress()->getStreet();
 echo $company->getAddress()->getStreetNumber();
+echo $company->getAddress()->getPostalCode();
 
 // ... etc

--- a/src/Models/CompanyAddress.php
+++ b/src/Models/CompanyAddress.php
@@ -52,9 +52,9 @@ class CompanyAddress
     /**
      * @return string
      */
-    public function getPostalCode()
+    public function getPostalCode(): ?string
     {
-        return $this->parser->getPostalCode();
+        return $this->parser->getAddress()['postalCode'];
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -5,6 +5,7 @@ class Parser
 {
     /** @var array */
     private $data = [];
+    private $address = [];
 
     /**
      * Parser constructor.
@@ -13,6 +14,33 @@ class Parser
     public function __construct(array $data)
     {
         $this->data = $data;
+
+        if (!empty($data['adresa'])) {
+            // Normal case from all uppercase
+            $rawText = mb_convert_case($data['adresa'], MB_CASE_TITLE, 'UTF-8');
+
+            // Parse address
+            $list = array_map('trim', explode(",", $rawText, 5));
+            list($county, $city, $street, $number, $other) = array_pad($list, 5, '');
+
+            // Parse county
+            $this->address['county'] = trim(str_replace('Jud.', '', $county));
+
+            // Parse city
+            $this->address['city'] = trim(str_replace(['Mun.', 'Orş.'], ['', 'Oraş'], $city));
+
+            // Parse street
+            $this->address['street'] = trim(str_replace('Str.', '', $street));
+
+            // Parse street number
+            $this->address['streetNumber'] = trim(str_replace('Nr.', '', $number));
+
+            // Parse others
+            $this->address['others'] = trim($other);
+        }
+
+        // Parse postal code
+        $this->address['postalCode'] = $data['codPostal'] ?? NULL;
     }
 
     /**
@@ -20,31 +48,7 @@ class Parser
      */
     public function getAddress(): array
     {
-        $address = [];
-
-        // Normal case from all uppercase
-        $rawText = mb_convert_case($this->data['adresa'], MB_CASE_TITLE, 'UTF-8');
-
-        // Parse address
-        $list = array_map('trim', explode(",", $rawText, 5));
-        list($county, $city, $street, $number, $other) = array_pad($list, 5, '');
-
-        // Parse county
-        $address['county'] = trim(str_replace('Jud.', '', $county));
-
-        // Parse city
-        $address['city'] = trim(str_replace(['Mun.', 'Orş.'], ['', 'Oraş'], $city));
-
-        // Parse street
-        $address['street'] = trim(str_replace('Str.', '', $street));
-
-        // Parse street number
-        $address['streetNumber'] = trim(str_replace('Nr.', '', $number));
-
-        // Parse others
-        $address['others'] = trim($other);
-
-        return $address;
+        return $this->address;
     }
 
     /**
@@ -62,13 +66,5 @@ class Parser
     public function getData(): array
     {
         return $this->data;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPostalCode()
-    {
-        return $this->data['codPostal'];
     }
 }

--- a/tests/Integrations/FlowTest.php
+++ b/tests/Integrations/FlowTest.php
@@ -47,5 +47,6 @@ class FlowTest extends TestCase
         $this->assertEquals("Oraş Voluntari", $results->getAddress()->getCity());
         $this->assertEquals("Şos. Bucureşti Nord", $results->getAddress()->getStreet());
         $this->assertEquals("15-23", $results->getAddress()->getStreetNumber());
+        $this->assertEquals("057003", $results->getAddress()->getPostalCode());
     }
 }

--- a/tests/Unit/Models/CompanyTest.php
+++ b/tests/Unit/Models/CompanyTest.php
@@ -24,6 +24,7 @@ class CompanyTest extends TestCase
             'city' => 'Sector 1',
             'street' => 'Şos. Bucureşti-Ploieşti',
             'streetNumber' => '172-176',
+            'postalCode' => '057003'
         ];
 
         $parset->expects($this->any())
@@ -37,9 +38,6 @@ class CompanyTest extends TestCase
                 'denumire' => 'Test',
                 'telefon' => 07676000000,
             ]));
-        $parset->expects($this->any())
-            ->method("getPostalCode")
-            ->will($this->returnValue("057003"));
 
         $company = new Company($parset);
         $this->assertEquals(123456, $company->getCIF());


### PR DESCRIPTION
Salut @itrack.

Codul aruncă eroare când ANAF nu returnează cod poștal.
Așa că l-am făcut opțional.

De asemenea, am pus parsarea în __construct(), ca să fie rulată _only once_.

Am rulat și testele cu PHPUnit 👌