### PR TITLE
Bug fix (#20): Fatal error: Uncaught TypeError: Argument 1 must be of the type array, null given

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -64,14 +64,14 @@ class Client
     }
 
     /**
-     * @return Company
+     * @return Company|null
      * @throws Exceptions\LimitExceeded
      * @throws Exceptions\RequestFailed
      * @throws Exceptions\ResponseFailed
      */
-    public function first(): Company
+    public function first(): ?Company
     {
         $results = Http::call($this->cifs);
-        return new Company(new Parser($results[0]));
+        return $results[0] ? new Company(new Parser($results[0])) : null;
     }
 }


### PR DESCRIPTION
If no results are returned from the CIF search, $results will be null, but calling Client->first() method will try to access $results[0], which will throw the given error. By checking if any results are found, the issue is safely avoided.