### PR TITLE
Upgrade to ANAF API v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $raspuns = $anaf->get();
 ```
 
 # Limite
-Poti solicita raspuns pentru maxim 500 de CUI-uri simultan cu o rata de 1 request / secunda. 
+Poti solicita raspuns pentru maxim 100 de CUI-uri simultan cu o rata de 1 request / secunda. 
 
 # Requirements
 * PHP >= 7.1 | >= 8
@@ -114,7 +114,7 @@ Poti solicita raspuns pentru maxim 500 de CUI-uri simultan cu o rata de 1 reques
 
 # Exceptii:
 
-* Itrack\Anaf\Exceptions\LimitExceeded - Ai depasit limita de 500 de CUI-uri / request;
+* Itrack\Anaf\Exceptions\LimitExceeded - Ai depasit limita de 100 de CUI-uri / request;
 * Itrack\Anaf\Exceptions\ResponseFailed - Raspunsul primit de la ANAF nu este in format JSON, exceptia returneaza body-ul raspunsului pentru a fi verificat manual;
 * Itrack\Anaf\Exceptions\RequestFailed - Raspunsul primit de la ANAF nu are status de succes, verifica manual raspunsul primit in exceptie.
 
@@ -125,4 +125,4 @@ Versiunea 2 nu este compatibila cu versiunea 3, daca aveti o implementare veche,
 [![Contribuitori](https://contributors-img.firebaseapp.com/image?repo=itrack/anaf)](https://github.com/itrack/anaf/graphs/contributors)
 
 # Linkuri utile
-https://webservicesp.anaf.ro/PlatitorTvaRest/api/v8/
+https://static.anaf.ro/static/10/Anaf/Informatii_R/Servicii_web/doc_WS_V9.txt

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage includeUncoveredFiles="true">
-    <include>
+  <filter>
+    <whitelist>
       <directory suffix=".php">src/</directory>
-    </include>
-    <exclude>
-      <directory>./tests</directory>
-      <directory>./vendor</directory>
-    </exclude>
-  </coverage>
+      <exclude>
+        <directory>./tests</directory>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
   <testsuites>
     <testsuite name="API Anaf Tests Suite">
       <directory>./tests/</directory>

--- a/src/Http.php
+++ b/src/Http.php
@@ -53,7 +53,15 @@ class Http
         curl_close($curl);
 
         // Check http code
-        if (!isset($info['http_code']) || $info['http_code'] !== 200) {
+        if (!isset($info['http_code'])) {
+            throw new Exceptions\ResponseFailed("Missing response status code");
+        }
+        
+        if ($info['http_code'] === 400) {
+            throw new Exceptions\ResponseFailed("Bad request: {$response}");
+        }
+        
+        if ($info['http_code'] !== 200) {
             throw new Exceptions\ResponseFailed("Response status: {$info['http_code']} | Response body: {$response}");
         }
 
@@ -71,9 +79,9 @@ class Http
             throw new Exceptions\ResponseFailed("Json parse error | Response body: {$response}");
         }
 
-        // Check success stats
-        if ("SUCCESS" !== $responseData['message'] || 200 !== $responseData['cod']) {
-            throw new Exceptions\RequestFailed("Response message: {$responseData['message']} | Response body: {$response}");
+        // Check if we have the expected structure
+        if (!isset($responseData['found'])) {
+            throw new Exceptions\RequestFailed("Invalid response format - missing 'found' field | Response body: {$response}");
         }
 
         return $responseData['found'];

--- a/src/Http.php
+++ b/src/Http.php
@@ -7,11 +7,11 @@ use Itrack\Anaf\Exceptions\ResponseFailed;
 
 class Http
 {
-    /** @var string API URL for v8 */
-    private const apiURL = 'https://webservicesp.anaf.ro/PlatitorTvaRest/api/v8/ws/tva';
+    /** @var string API URL for v9 */
+    private const apiURL = 'https://webservicesp.anaf.ro/api/PlatitorTvaRest/v9/tva';
 
     /** @var int Limit for one time call */
-    public const CIF_LIMIT = 500;
+    public const CIF_LIMIT = 100;
 
     /** @var int Max. number of retries */
     public const RETRIES_LIMIT = 5;
@@ -31,7 +31,7 @@ class Http
     {
         // Limit maxim numbers of cifs
         if(count($cifs) >= self::CIF_LIMIT) {
-            throw new Exceptions\LimitExceeded('You can check one time up to 500 cifs.');
+            throw new Exceptions\LimitExceeded('You can check one time up to 100 cifs.');
         }
 
         // Make request

--- a/tests/Integrations/FlowTest.php
+++ b/tests/Integrations/FlowTest.php
@@ -45,9 +45,9 @@ class FlowTest extends TestCase
         $anaf->addCif("RO14399840");
         $results = $anaf->first();
 
-        $this->assertEquals("Ilfov", $results->getAddress()->getCounty());
-        $this->assertEquals("Oraş Voluntari", $results->getAddress()->getCity());
-        $this->assertEquals("Şos. Bucureşti Nord", $results->getAddress()->getStreet());
-        $this->assertEquals("15-23", $results->getAddress()->getStreetNumber());
+        $this->assertEquals("Municipiul Bucureşti", $results->getAddress()->getCounty());
+        $this->assertEquals("Sector 2", $results->getAddress()->getCity());
+        $this->assertEquals("Gara Herăstrău", $results->getAddress()->getStreet());
+        $this->assertEquals("6", $results->getAddress()->getStreetNumber());
     }
 }

--- a/tests/Unit/HttpTest.php
+++ b/tests/Unit/HttpTest.php
@@ -9,8 +9,8 @@ class HttpTest extends TestCase
     public function testCifLimitException()
     {
         $this->expectException(Exceptions\LimitExceeded::class);
-        $this->expectExceptionMessage("You can check one time up to 500 cifs.");
+        $this->expectExceptionMessage("You can check one time up to 100 cifs.");
         
-        Http::call(array_fill(0, 501, '123456'));
+        Http::call(array_fill(0, 101, '123456'));
     }
 }


### PR DESCRIPTION
Updated the API to the new version - v9.

Additionally:
- updated CIFs count limit to 100 (v9 only supports 100)
- updated response processing and error handling as they're different than the official documentation

V9 API docs: https://static.anaf.ro/static/10/Anaf/Informatii_R/Servicii_web/doc_WS_V9.txt